### PR TITLE
Fixed input group CSS

### DIFF
--- a/src/main/less/themes/ashes/less/style.less
+++ b/src/main/less/themes/ashes/less/style.less
@@ -415,8 +415,7 @@ label,
   font-weight: normal;
 }
  
-.input-group-addon,
-.input-group-btn .btn {
+.input-group-addon {
   padding: 8px 14px;
   font-size: @font-size-small;
 }


### PR DESCRIPTION
Input groups were misaligned because the font size was being changed and padding was being added to buttons,
by removing this padding the buttons and input fields are now aligned.
